### PR TITLE
Expose more internal record APIs

### DIFF
--- a/starlark/src/coerce.rs
+++ b/starlark/src/coerce.rs
@@ -112,6 +112,9 @@ where
 
 unsafe impl<From, To> Coerce<SmallSet<To>> for SmallSet<From> where From: Coerce<To> {}
 
+unsafe impl<From, To> Coerce<Option<To>> for Option<From> where From: Coerce<To> {}
+unsafe impl<From, To> CoerceKey<Option<To>> for Option<From> where From: CoerceKey<To> {}
+
 /// Safely convert between types which have a `Coerce` relationship.
 /// Often the second type argument will need to be given explicitly,
 /// e.g. `coerce::<_, ToType>(x)`.

--- a/starlark/src/environment/modules.rs
+++ b/starlark/src/environment/modules.rs
@@ -24,6 +24,7 @@ use std::cell::Cell;
 use std::cell::RefCell;
 use std::mem;
 use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 use allocative::Allocative;
@@ -430,6 +431,7 @@ impl Module {
             extra_value,
             heap_profile_on_freeze,
         } = self;
+        #[cfg(not(target_arch = "wasm32"))]
         let start = Instant::now();
         // This is when we do the GC/freeze, using the module slots as roots
         // Note that we even freeze anonymous slots, since they are accessed by
@@ -463,11 +465,16 @@ impl Module {
         // but can now be dropped
         mem::drop(heap);
 
+        #[cfg(not(target_arch = "wasm32"))]
+        let total_eval_duration = start.elapsed() + eval_duration.get();
+        #[cfg(target_arch = "wasm32")]
+        let total_eval_duration = eval_duration.get();
+
         Ok(FrozenModule {
             heap: freezer.into_ref(),
             module: frozen_module_ref,
             extra_value,
-            eval_duration: start.elapsed() + eval_duration.get(),
+            eval_duration: total_eval_duration,
         })
     }
 

--- a/starlark/src/values.rs
+++ b/starlark/src/values.rs
@@ -129,7 +129,8 @@ pub(crate) mod thin_box_slice_frozen_value;
 mod trace;
 pub(crate) mod traits;
 pub mod type_repr;
-pub(crate) mod types;
+/// Types and type system support for Starlark values.
+pub mod types;
 pub mod typing;
 mod unpack;
 mod unpack_and_discard;

--- a/starlark/src/values/types/enumeration/enum_type.rs
+++ b/starlark/src/values/types/enumeration/enum_type.rs
@@ -207,7 +207,7 @@ impl<'v> EnumType<'v> {
 }
 
 impl<V: EnumCell + Freeze> EnumTypeGen<V> {
-    pub(crate) fn elements(&self) -> &SmallMap<V, V> {
+    pub fn elements(&self) -> &SmallMap<V, V> {
         // Safe because we never mutate the elements after construction.
         unsafe { &*self.elements.get() }
     }

--- a/starlark/src/values/types/record.rs
+++ b/starlark/src/values/types/record.rs
@@ -41,7 +41,8 @@
 //! # "#);
 //! ```
 
-pub(crate) mod field;
+/// Field specifications for record types.
+pub mod field;
 pub(crate) mod globals;
 pub(crate) mod instance;
 pub(crate) mod matcher;

--- a/starlark/src/values/types/record.rs
+++ b/starlark/src/values/types/record.rs
@@ -49,4 +49,5 @@ pub(crate) mod record_type;
 pub(crate) mod ty_record_type;
 
 pub use crate::values::record::instance::Record;
+pub use crate::values::record::record_type::FrozenRecordType;
 pub use crate::values::record::record_type::RecordType;

--- a/starlark/src/values/types/record.rs
+++ b/starlark/src/values/types/record.rs
@@ -49,3 +49,4 @@ pub(crate) mod record_type;
 pub(crate) mod ty_record_type;
 
 pub use crate::values::record::instance::Record;
+pub use crate::values::record::record_type::RecordType;

--- a/starlark/src/values/types/record.rs
+++ b/starlark/src/values/types/record.rs
@@ -47,7 +47,8 @@ pub(crate) mod globals;
 pub(crate) mod instance;
 pub(crate) mod matcher;
 pub(crate) mod record_type;
-pub(crate) mod ty_record_type;
+/// Type information for record types.
+pub mod ty_record_type;
 
 pub use crate::values::record::instance::FrozenRecord;
 pub use crate::values::record::instance::Record;

--- a/starlark/src/values/types/record.rs
+++ b/starlark/src/values/types/record.rs
@@ -48,6 +48,7 @@ pub(crate) mod matcher;
 pub(crate) mod record_type;
 pub(crate) mod ty_record_type;
 
+pub use crate::values::record::instance::FrozenRecord;
 pub use crate::values::record::instance::Record;
 pub use crate::values::record::record_type::FrozenRecordType;
 pub use crate::values::record::record_type::RecordType;

--- a/starlark/src/values/types/record/field.rs
+++ b/starlark/src/values/types/record/field.rs
@@ -78,6 +78,16 @@ impl<V: ValueLifetimeless> FieldGen<V> {
     pub(crate) fn new(typ: TypeCompiled<V>, default: Option<V>) -> Self {
         Self { typ, default }
     }
+
+    /// Get the type specification for this field (public accessor)
+    pub fn typ(&self) -> &TypeCompiled<V> {
+        &self.typ
+    }
+
+    /// Get the default value for this field (public accessor)
+    pub fn default(&self) -> Option<&V> {
+        self.default.as_ref()
+    }
 }
 
 impl<'v, V: ValueLike<'v>> FieldGen<V> {

--- a/starlark/src/values/types/record/record_type.rs
+++ b/starlark/src/values/types/record/record_type.rs
@@ -178,7 +178,7 @@ where
     Self: ProvidesStaticType<'v>,
     FieldGen<V>: ProvidesStaticType<'v>,
 {
-    pub(crate) fn ty_record_data(&self) -> Option<&Arc<TyRecordData>> {
+    pub fn ty_record_data(&self) -> Option<&Arc<TyRecordData>> {
         V::get_ty(&self.ty_record_data)
     }
 
@@ -187,6 +187,11 @@ where
             .expect("Instances can only be created if named are assigned")
             .ty_record
             .dupe()
+    }
+
+    /// Get the field definitions of this record type (public accessor for field introspection)
+    pub fn fields(&self) -> &SmallMap<String, FieldGen<V>> {
+        &self.fields
     }
 
     fn make_parameter_spec(

--- a/starlark/src/values/types/record/ty_record_type.rs
+++ b/starlark/src/values/types/record/ty_record_type.rs
@@ -26,7 +26,7 @@ use crate::values::types::type_instance_id::TypeInstanceId;
 #[doc(hidden)]
 pub struct TyRecordData {
     /// Name of the record type.
-    pub(crate) name: String,
+    pub name: String,
     /// Globally unique id of the record type.
     pub(crate) id: TypeInstanceId,
     /// Type of record instance.

--- a/starlark/src/values/typing/type_compiled/compiled.rs
+++ b/starlark/src/values/typing/type_compiled/compiled.rs
@@ -327,6 +327,17 @@ impl<'v, V: ValueLike<'v>> TypeCompiled<V> {
         self.0
     }
 
+    /// Get the name of a custom type (like enum name) if this type represents a custom type
+    pub fn custom_type_name(&self) -> Option<&'v str> {
+        match self.downcast() {
+            Ok(type_compiled_dyn) => {
+                let ty = type_compiled_dyn.as_ty_dyn();
+                ty.as_name()
+            }
+            Err(_) => None,
+        }
+    }
+
     pub(crate) fn write_hash(self, hasher: &mut StarlarkHasher) -> crate::Result<()> {
         self.to_value().0.write_hash(hasher)
     }

--- a/starlark_lsp/src/server.rs
+++ b/starlark_lsp/src/server.rs
@@ -33,9 +33,7 @@ use itertools::Itertools;
 use lsp_server::Connection;
 use lsp_server::Message;
 use lsp_server::Notification;
-use lsp_server::Request;
 use lsp_server::RequestId;
-use lsp_server::Response;
 use lsp_server::ResponseError;
 use lsp_types::CompletionItem;
 use lsp_types::CompletionItemKind;
@@ -98,6 +96,9 @@ use starlark_syntax::codemap::ResolvedPos;
 use starlark_syntax::syntax::ast::AstPayload;
 use starlark_syntax::syntax::ast::LoadArgP;
 use starlark_syntax::syntax::module::AstModuleFields;
+
+pub use lsp_server::Request;
+pub use lsp_server::Response;
 
 use crate::completion::StringCompletionResult;
 use crate::completion::StringCompletionType;

--- a/starlark_lsp/src/test.rs
+++ b/starlark_lsp/src/test.rs
@@ -297,6 +297,23 @@ impl LspContext for TestServerContext {
                 .collect(),
         }
     }
+
+    fn handle_custom_request(
+        &self,
+        req: &lsp_server::Request,
+        _initialize_params: &lsp_types::InitializeParams,
+    ) -> Option<lsp_server::Response> {
+        if req.method == "starlark/echo" {
+            let payload: String = serde_json::from_value(req.params.clone()).ok()?;
+            Some(lsp_server::Response {
+                id: req.id.clone(),
+                result: Some(serde_json::to_value(format!("echo:{}", payload)).unwrap()),
+                error: None,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 /// A server for use in testing that provides helpers for sending requests, correlating


### PR DESCRIPTION
This is needed for us to deserialize records from json, which is used by the metadata system.