### PR TITLE
support field access in fstrings

### DIFF
--- a/starlark/src/tests/fstring.rs
+++ b/starlark/src/tests/fstring.rs
@@ -106,6 +106,12 @@ f"{x}" == '("x",)'
         assert().is_true(r#"x = 'a'; f"{x!s}" == 'a'"#);
         assert().is_true(r#"x = 'a'; f"{x!r}" == '"a"'"#);
     }
+
+    #[test]
+    fn dot_expression() {
+        assert().is_true(r#"x = struct(y = "a"); f"{x.y}" == "a""#);
+        assert().is_true(r#"x = struct(y = "a"); f"{ x . y }" == "a""#);
+    }
 }
 
 mod fail {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/starlark-rust/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates f-string parsing to accept `a.b`-style field access, which could subtly affect parsing/diagnostics (spans and error messages) for format captures. Change is localized to syntax parsing with added tests to constrain behavior.
> 
> **Overview**
> Enables **field access inside f-string captures** by parsing capture contents as an identifier-with-dot chain (e.g. `f"{x.y}"`), including optional whitespace around identifiers and dots.
> 
> Replaces the previous “single identifier only” capture handling with a small parser that builds `ExprP::Dot` AST nodes and rejects non-dot expressions like indexing; adds unit tests plus a new runtime test covering `struct` field access in f-strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd12784d484b60ced8edd96383a04d4aff724224. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->