### PR TITLE
Allow `export_as` to replace stored module bindings

### DIFF
--- a/starlark/src/eval/bc/instr_impl.rs
+++ b/starlark/src/eval/bc/instr_impl.rs
@@ -259,7 +259,11 @@ impl InstrNoFlowImpl for InstrStoreModuleAndExportImpl {
         (source, slot, name): &(BcSlotIn, ModuleSlotId, String),
     ) -> crate::Result<()> {
         let v = frame.get_bc_slot(*source);
-        v.export_as(name.as_str(), eval)?;
+        let previous = eval.take_export_as_replacement();
+        debug_assert!(previous.is_none(), "stale `export_as` replacement");
+        let export_result = v.export_as(name.as_str(), eval);
+        let v = eval.take_export_as_replacement().unwrap_or(v);
+        export_result?;
         eval.set_slot_module(*slot, v);
         Ok(())
     }

--- a/starlark/src/eval/runtime/evaluator.rs
+++ b/starlark/src/eval/runtime/evaluator.rs
@@ -106,6 +106,8 @@ enum EvaluatorError {
     ZeroCallstackSize,
     #[error("Evaluation cancelled")]
     Cancelled,
+    #[error("`export_as` replacement already set (internal error)")]
+    ExportAsReplacementAlreadySet,
 }
 
 /// Number of bytes to allocate between GC's.
@@ -173,6 +175,8 @@ pub struct Evaluator<'v, 'a, 'e> {
     pub(crate) is_cancelled: Box<dyn Fn() -> bool + 'a>,
     /// A counter to track when to perform "infrequent" checks like cancellation, timeouts, etc
     pub(crate) infrequent_instr_check_counter: u32,
+    /// Replacement value requested by `export_as` for the next module binding store.
+    pub(crate) export_as_replacement: Option<Value<'v>>,
 }
 
 // We use this to validate that the Evaluator lifetimes have the expected variance.
@@ -266,6 +270,7 @@ impl<'v, 'a, 'e: 'a> Evaluator<'v, 'a, 'e> {
             max_callstack_size: None,
             is_cancelled: Box::new(|| false),
             infrequent_instr_check_counter: 0,
+            export_as_replacement: None,
         }
     }
 
@@ -643,9 +648,29 @@ impl<'v, 'a, 'e: 'a> Evaluator<'v, 'a, 'e> {
         name: &str,
         value: Value<'v>,
     ) -> crate::Result<()> {
-        value.export_as(name, self)?;
+        let previous = self.take_export_as_replacement();
+        debug_assert!(previous.is_none(), "stale `export_as` replacement");
+        let export_result = value.export_as(name, self);
+        let value = self.take_export_as_replacement().unwrap_or(value);
+        export_result?;
         self.module_env.set(name, value);
         Ok(())
+    }
+
+    /// Request that the next top-level module binding store use `value`
+    /// instead of the value whose `export_as` hook is currently running.
+    pub fn set_export_as_replacement(&mut self, value: Value<'v>) -> crate::Result<()> {
+        if self.export_as_replacement.is_some() {
+            return Err(crate::Error::new_other(
+                EvaluatorError::ExportAsReplacementAlreadySet,
+            ));
+        }
+        self.export_as_replacement = Some(value);
+        Ok(())
+    }
+
+    pub(crate) fn take_export_as_replacement(&mut self) -> Option<Value<'v>> {
+        self.export_as_replacement.take()
     }
 
     pub(crate) fn set_slot_module(&mut self, slot: ModuleSlotId, value: Value<'v>) {
@@ -752,6 +777,7 @@ impl<'v, 'a, 'e: 'a> Evaluator<'v, 'a, 'e> {
         self.current_frame.trace(tracer);
         self.call_stack.trace(tracer);
         self.time_flame_profile.trace(tracer);
+        self.export_as_replacement.trace(tracer);
     }
 
     /// Perform a garbage collection.

--- a/starlark/src/values/types/record/field.rs
+++ b/starlark/src/values/types/record/field.rs
@@ -74,6 +74,7 @@ unsafe impl<From: Coerce<To> + ValueLifetimeless, To: ValueLifetimeless> Coerce<
 starlark_complex_value!(pub(crate) Field);
 
 impl<V: ValueLifetimeless> FieldGen<V> {
+    /// Create a record field with its compiled type and optional default.
     pub fn new(typ: TypeCompiled<V>, default: Option<V>) -> Self {
         Self { typ, default }
     }


### PR DESCRIPTION
This is needed for `io()` and `config()` to extract the right property in `export_as`. Currently, `export_as` can only mutate a value, it can't rebind it. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes module-binding storage semantics during `export_as`, which can subtly affect top-level evaluation and module state if the replacement is misused or left stale.
> 
> **Overview**
> `export_as` can now request a *replacement value* to be stored for the next top-level module binding write, instead of only mutating the original value.
> 
> This introduces `Evaluator::set_export_as_replacement`/`take_export_as_replacement` with GC tracing and an internal error if replacements are set twice, and updates both bytecode `InstrStoreModuleAndExport` and `Evaluator::set_module_variable_at_some_point` to honor the replacement after running `export_as`.
> 
> Separately, adds a clarifying doc comment on `FieldGen::new`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b4043569c64642edde3c0398e026d34c672e9b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/starlark-rust/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
