### PR TITLE
Serialize i32-range big ints as JSON numbers

### DIFF
--- a/starlark/src/values/types/bigint.rs
+++ b/starlark/src/values/types/bigint.rs
@@ -137,7 +137,11 @@ impl Serialize for StarlarkBigInt {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.value.to_string())
+        if let Some(value) = self.to_i32() {
+            value.serialize(serializer)
+        } else {
+            serializer.serialize_str(&self.value.to_string())
+        }
     }
 }
 
@@ -687,6 +691,18 @@ mod tests {
             "123456789012345678901234567890",
             "int(123456789012345678901234567890)",
         );
+    }
+
+    #[test]
+    fn test_json_serialization() {
+        let big = StarlarkBigInt::unchecked_new(BigInt::from(i64::from(i32::MAX) + 1));
+        assert_eq!(serde_json::to_string(&big).unwrap(), "\"2147483648\"");
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn test_json_serialization_i32_range_on_32_bit() {
+        assert_eq!(assert::pass("2147483647").to_json().unwrap(), "2147483647");
     }
 
     #[test]


### PR DESCRIPTION
Fix wasm JSON serialization for big ints that still fit in `i32`.

On wasm32, values like `2147483647` become `StarlarkBigInt` because inline ints are smaller than on native. We were serializing all big ints as strings, so wasm produced `"2147483647"` while native produced `2147483647`.

Now we serialize big ints as JSON numbers when they fit in `i32`, and keep string serialization for truly large ints. This makes the same Starlark program produce the same JSON on every platform for normal `i32`-sized integers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes `StarlarkBigInt` JSON serialization behavior and adds targeted tests; main risk is a small cross-platform output format change for values that were previously serialized as strings.
> 
> **Overview**
> Adjusts `StarlarkBigInt`’s `Serialize` impl to emit a JSON *number* when the bigint can be represented as an `i32`, and otherwise keep the previous behavior of emitting a JSON string for larger values.
> 
> Adds regression tests to ensure values above `i32::MAX` still serialize as strings, and (on 32-bit targets) that `i32`-range integers serialize as numbers to keep JSON output consistent across platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad7ca8cc1618f3693144575ad875c1e9982123c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->