### PR TITLE
All Diode patches on top of new `main`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ postcard = { version = "1.0.8", features = ["use-crc", "use-std"] }
 regex = "1.12.3"
 sequence_trie = "0.3.6"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["raw_value"] }
+serde_json = "1.0.140"
 sled = "0.34.7"
 smallvec = { version = "1.15", features = ["const_generics"] }
 sorted_vector_map.git = "https://github.com/facebookexperimental/rust-shed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ ref-cast = "1.0.18"
 relative-path = { version = "1.7.0", features = ["serde"] }
 syn = { version = "2.0.117", features = ["full"] }
 
-pagable = { version = "0.3.3", path = "pagable", features = ["tokio"] }
+pagable = { version = "0.3.3", path = "pagable" }
 # dependencies of pagable
 async-trait = "0.1.86"
 blake3 = { version = "=1.8.2", features = ["default", "rayon", "std", "traits-preview"] }
@@ -67,10 +67,7 @@ regex = "1.12.3"
 sequence_trie = "0.3.6"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.140"
-sled = "0.34.7"
 smallvec = { version = "1.15", features = ["const_generics"] }
-sorted_vector_map.git = "https://github.com/facebookexperimental/rust-shed"
-sorted_vector_map.version = "0.2"
 static_assertions = "1.1.0"
 static_interner = "0.1.2"
 take_mut = "0.2"

--- a/pagable/Cargo.toml
+++ b/pagable/Cargo.toml
@@ -25,7 +25,7 @@ pagable_derive = { version = "=0.3.3", path = "../pagable_derive" }
 parking_lot = { workspace = true }
 postcard = { workspace = true }
 regex = { workspace = true }
-rusqlite = { version = "0.37.0", features = ["bundled"] }
+rusqlite = { version = "0.39.0", features = ["bundled"] }
 sequence_trie = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/pagable/Cargo.toml
+++ b/pagable/Cargo.toml
@@ -25,13 +25,10 @@ pagable_derive = { version = "=0.3.3", path = "../pagable_derive" }
 parking_lot = { workspace = true }
 postcard = { workspace = true }
 regex = { workspace = true }
-rusqlite = { version = "0.39.0", features = ["bundled"] }
 sequence_trie = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sled = { workspace = true }
 smallvec = { workspace = true }
-sorted_vector_map = { workspace = true }
 static_assertions = { workspace = true }
 static_interner = { workspace = true }
 strong_hash = { workspace = true }

--- a/pagable/src/impls/collections.rs
+++ b/pagable/src/impls/collections.rs
@@ -10,7 +10,6 @@
 
 use serde::Deserialize;
 use serde::Serialize;
-use sorted_vector_map::SortedVectorMap;
 
 use crate::traits::PagableDeserialize;
 use crate::traits::PagableDeserializer;
@@ -100,36 +99,6 @@ impl<'de, K: std::hash::Hash + Eq + PagableDeserialize<'de>, V: PagableDeseriali
             let k = Vec::<K>::pagable_deserialize(deserializer)?;
             let v = V::pagable_deserialize(deserializer)?;
             map.insert_owned(k, v);
-        }
-        Ok(map)
-    }
-}
-
-impl<K: PagableSerialize, V: PagableSerialize> PagableSerialize for SortedVectorMap<K, V>
-where
-    K: Ord,
-{
-    fn pagable_serialize(&self, serializer: &mut dyn PagableSerializer) -> crate::Result<()> {
-        usize::serialize(&self.len(), serializer.serde())?;
-        for (k, v) in self {
-            k.pagable_serialize(serializer)?;
-            v.pagable_serialize(serializer)?;
-        }
-        Ok(())
-    }
-}
-impl<'de, K: Ord + PagableDeserialize<'de>, V: PagableDeserialize<'de>> PagableDeserialize<'de>
-    for SortedVectorMap<K, V>
-{
-    fn pagable_deserialize<D: PagableDeserializer<'de> + ?Sized>(
-        deserializer: &mut D,
-    ) -> crate::Result<Self> {
-        let items = usize::deserialize(deserializer.serde())?;
-        let mut map = SortedVectorMap::new();
-        for _ in 0..items {
-            let k = K::pagable_deserialize(deserializer)?;
-            let v = V::pagable_deserialize(deserializer)?;
-            map.insert(k, v);
         }
         Ok(map)
     }
@@ -388,27 +357,6 @@ mod tests {
         for (k, v) in &original {
             assert_eq!(restored.get(k.iter().map(|s| s.as_str())), Some(v));
         }
-        Ok(())
-    }
-
-    #[test]
-    fn test_sorted_vector_map_roundtrip() -> crate::Result<()> {
-        use sorted_vector_map::SortedVectorMap;
-
-        let mut map: SortedVectorMap<String, i32> = SortedVectorMap::new();
-        map.insert("one".to_owned(), 1);
-        map.insert("two".to_owned(), 2);
-        map.insert("three".to_owned(), 3);
-
-        let mut serializer = TestingSerializer::new();
-        map.pagable_serialize(&mut serializer)?;
-        let bytes = serializer.finish();
-
-        let mut deserializer = TestingDeserializer::new(&bytes);
-        let restored: SortedVectorMap<String, i32> =
-            SortedVectorMap::pagable_deserialize(&mut deserializer)?;
-
-        assert_eq!(map, restored);
         Ok(())
     }
 

--- a/pagable/src/storage.rs
+++ b/pagable/src/storage.rs
@@ -11,7 +11,5 @@
 pub mod data;
 pub mod handle;
 pub mod in_memory;
-pub mod sled;
-pub mod sqlite;
 pub mod support;
 pub mod traits;

--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -45,7 +45,6 @@ ref-cast = "1.0.18"
 regex = "1.5.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
-sled = "0.34"
 starlark_derive = { version = "=0.14.0", path = "../starlark_derive" }
 starlark_map = { version = "0.14.0", path = "../starlark_map", features = ["pagable_dep"] }
 starlark_syntax = { version = "0.14.0", path = "../starlark_syntax" }

--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -54,6 +54,7 @@ strong_hash = { workspace = true }
 strsim = "0.10.0"
 textwrap = "0.11"
 thiserror = "2.0.18"
+rust_decimal = "1.38.0"
 
 allocative = { workspace = true, features = ["bumpalo", "num-bigint"] }
 cmp_any = { workspace = true }

--- a/starlark/src/coerce.rs
+++ b/starlark/src/coerce.rs
@@ -112,6 +112,9 @@ where
 
 unsafe impl<From, To> Coerce<SmallSet<To>> for SmallSet<From> where From: Coerce<To> {}
 
+unsafe impl<From, To> Coerce<Option<To>> for Option<From> where From: Coerce<To> {}
+unsafe impl<From, To> CoerceKey<Option<To>> for Option<From> where From: CoerceKey<To> {}
+
 /// Safely convert between types which have a `Coerce` relationship.
 /// Often the second type argument will need to be given explicitly,
 /// e.g. `coerce::<_, ToType>(x)`.

--- a/starlark/src/environment/modules.rs
+++ b/starlark/src/environment/modules.rs
@@ -25,6 +25,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 use allocative::Allocative;
@@ -565,14 +566,16 @@ impl<'v> Module<'v> {
             frozen_def.post_freeze(frozen_module_ref, heap, freezer.heap);
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        let total_eval_duration = start.elapsed() + eval_duration.get();
+        #[cfg(target_arch = "wasm32")]
+        let total_eval_duration = eval_duration.get();
+
         Ok(FrozenModule {
             heap: frozen_heap.into_ref_impl(name, Some(heap.peak_allocated_bytes())),
             module: frozen_module_ref,
             extra_value,
-            #[cfg(not(target_arch = "wasm32"))]
-            eval_duration: start.elapsed() + eval_duration.get(),
-            #[cfg(target_arch = "wasm32")]
-            eval_duration: eval_duration.get(),
+            eval_duration: total_eval_duration,
         })
     }
 

--- a/starlark/src/eval/bc/instr_impl.rs
+++ b/starlark/src/eval/bc/instr_impl.rs
@@ -261,7 +261,7 @@ impl InstrNoFlowImpl for InstrStoreModuleAndExportImpl {
         (source, slot, name): &(BcSlotIn, ModuleSlotId, String),
     ) -> crate::Result<()> {
         let v = frame.get_bc_slot(*source);
-        v.export_as(name.as_str(), eval)?;
+        let v = eval.export_as_module_binding(name.as_str(), v)?;
         eval.set_slot_module(*slot, v);
         Ok(())
     }

--- a/starlark/src/eval/runtime/evaluator.rs
+++ b/starlark/src/eval/runtime/evaluator.rs
@@ -122,6 +122,10 @@ be informative."
     ZeroTickLimit,
     #[error("Execution duration limit of {0} ticks has been exceeded")]
     TickLimitExceeded(u64),
+    #[error("`export_as` replacement already set (internal error)")]
+    ExportAsReplacementAlreadySet,
+    #[error("`export_as` replacement set outside `export_as` (internal error)")]
+    ExportAsReplacementNotActive,
 }
 
 /// Number of bytes to allocate between GC's.
@@ -201,6 +205,8 @@ pub struct Evaluator<'v, 'a, 'e> {
     pub(crate) infrequent_instr_check_counter: u32,
     /// Total number of ticks executed so far
     pub(crate) total_tick_count_at_last_infrequent_check: u64,
+    /// Replacement values requested by active `export_as` hooks.
+    pub(crate) export_as_replacements: Vec<Option<Value<'v>>>,
 }
 
 // We use this to validate that the Evaluator lifetimes have the expected variance.
@@ -300,6 +306,7 @@ impl<'v, 'a, 'e: 'a> Evaluator<'v, 'a, 'e> {
             is_cancelled: Box::new(|| false),
             infrequent_instr_check_counter: 0,
             total_tick_count_at_last_infrequent_check: 0,
+            export_as_replacements: Vec::new(),
         }
     }
 
@@ -683,9 +690,40 @@ impl<'v, 'a, 'e: 'a> Evaluator<'v, 'a, 'e> {
         name: &str,
         value: Value<'v>,
     ) -> crate::Result<()> {
-        value.export_as(name, self)?;
+        let value = self.export_as_module_binding(name, value)?;
         self.module_env.set(name, value);
         Ok(())
+    }
+
+    /// Request that the next top-level module binding store use `value`
+    /// instead of the value whose `export_as` hook is currently running.
+    pub fn set_export_as_replacement(&mut self, value: Value<'v>) -> crate::Result<()> {
+        let replacement = self
+            .export_as_replacements
+            .last_mut()
+            .ok_or_else(|| crate::Error::new_other(EvaluatorError::ExportAsReplacementNotActive))?;
+        if replacement.is_some() {
+            return Err(crate::Error::new_other(
+                EvaluatorError::ExportAsReplacementAlreadySet,
+            ));
+        }
+        *replacement = Some(value);
+        Ok(())
+    }
+
+    pub(crate) fn export_as_module_binding(
+        &mut self,
+        name: &str,
+        value: Value<'v>,
+    ) -> crate::Result<Value<'v>> {
+        self.export_as_replacements.push(None);
+        let export_result = value.export_as(name, self);
+        let replacement = self
+            .export_as_replacements
+            .pop()
+            .expect("export_as replacement stack underflow");
+        export_result?;
+        Ok(replacement.unwrap_or(value))
     }
 
     pub(crate) fn set_slot_module(&mut self, slot: ModuleSlotId, value: Value<'v>) {
@@ -804,6 +842,9 @@ impl<'v, 'a, 'e: 'a> Evaluator<'v, 'a, 'e> {
         self.time_flame_profile
             .record_call_enter(const_frozen_string!("trace/walk (profiling)").to_value());
         self.time_flame_profile.trace(tracer);
+        for replacement in &mut self.export_as_replacements {
+            replacement.trace(tracer);
+        }
         self.time_flame_profile.record_call_exit();
     }
 

--- a/starlark/src/tests/uncategorized.rs
+++ b/starlark/src/tests/uncategorized.rs
@@ -836,6 +836,70 @@ assert_eq(len(count), 1)
 }
 
 #[test]
+fn test_export_as_replacement_nested_module_bind() {
+    #[derive(
+        Debug,
+        Display,
+        ProvidesStaticType,
+        NoSerialize,
+        Allocative,
+        StarlarkPagable
+    )]
+    #[display("export_replacement")]
+    struct ExportReplacement {
+        replacement: String,
+        bind_nested: bool,
+    }
+    starlark_simple_value!(ExportReplacement);
+
+    #[starlark_value(type = "export_replacement", skip_pagable)]
+    impl<'v> StarlarkValue<'v> for ExportReplacement {
+        fn export_as(
+            &self,
+            variable_name: &str,
+            eval: &mut Evaluator<'v, '_, '_>,
+        ) -> crate::Result<()> {
+            let replacement = eval
+                .heap()
+                .alloc_str(&format!("{}:{variable_name}", self.replacement))
+                .to_value();
+            eval.set_export_as_replacement(replacement)?;
+
+            if self.bind_nested {
+                let nested = eval.heap().alloc(ExportReplacement {
+                    replacement: "inner".to_owned(),
+                    bind_nested: false,
+                });
+                eval.set_module_variable_at_some_point("nested", nested)?;
+            }
+
+            Ok(())
+        }
+    }
+
+    #[starlark_module]
+    fn module(builder: &mut GlobalsBuilder) {
+        fn export_replacement<'v>(heap: Heap<'v>) -> anyhow::Result<Value<'v>> {
+            Ok(heap.alloc(ExportReplacement {
+                replacement: "outer".to_owned(),
+                bind_nested: true,
+            }))
+        }
+    }
+
+    let mut a = Assert::new();
+    a.globals_add(module);
+    a.pass(
+        r#"
+nested = None
+value = export_replacement()
+assert_eq(value, "outer:value")
+assert_eq(nested, "inner:nested")
+"#,
+    );
+}
+
+#[test]
 fn test_self_mutate_list() {
     // Check functions that mutate and access self on lists
     let mut a = Assert::new();

--- a/starlark/src/typing/custom.rs
+++ b/starlark/src/typing/custom.rs
@@ -86,6 +86,16 @@ pub trait TyCustomImpl:
         let _unused = (bin_op, rhs, ctx);
         Err(TypingNoContextOrInternalError::Typing)
     }
+    /// Result type of `lhs <op> self`.
+    fn rbin_op(
+        &self,
+        bin_op: TypingBinOp,
+        lhs: &TyBasic,
+        ctx: &TypingOracleCtx,
+    ) -> Result<Ty, TypingNoContextOrInternalError> {
+        let _unused = (bin_op, lhs, ctx);
+        Err(TypingNoContextOrInternalError::Typing)
+    }
     /// Element type when iterating (`for x in self`).
     fn iter_item(&self) -> Result<Ty, TypingNoContextError> {
         Err(TypingNoContextError)
@@ -149,6 +159,12 @@ pub(crate) trait TyCustomDyn:
         &self,
         bin_op: TypingBinOp,
         rhs: &TyBasic,
+        ctx: &TypingOracleCtx,
+    ) -> Result<Ty, TypingNoContextOrInternalError>;
+    fn rbin_op_dyn(
+        &self,
+        bin_op: TypingBinOp,
+        lhs: &TyBasic,
         ctx: &TypingOracleCtx,
     ) -> Result<Ty, TypingNoContextOrInternalError>;
     fn union2_dyn(
@@ -236,6 +252,15 @@ impl<T: TyCustomImpl> TyCustomDyn for T {
         ctx: &TypingOracleCtx,
     ) -> Result<Ty, TypingNoContextOrInternalError> {
         self.bin_op(bin_op, rhs, ctx)
+    }
+
+    fn rbin_op_dyn(
+        &self,
+        bin_op: TypingBinOp,
+        lhs: &TyBasic,
+        ctx: &TypingOracleCtx,
+    ) -> Result<Ty, TypingNoContextOrInternalError> {
+        self.rbin_op(bin_op, lhs, ctx)
     }
 
     fn union2_dyn(

--- a/starlark/src/typing/oracle/ctx.rs
+++ b/starlark/src/typing/oracle/ctx.rs
@@ -678,6 +678,7 @@ impl<'a> TypingOracleCtx<'a> {
                 }
                 _ => Ok(TyStarlarkValue::tuple().rbin_op(bin_op, lhs)?),
             },
+            TyBasic::Custom(rhs) => Ok(rhs.0.rbin_op_dyn(bin_op, lhs, self)?),
             _ => Err(TypingNoContextOrInternalError::Typing),
         }
     }

--- a/starlark/src/typing/user.rs
+++ b/starlark/src/typing/user.rs
@@ -296,6 +296,24 @@ impl TyCustomImpl for TyUser {
         }
         self.supertypes.iter().any(|x| x == other)
     }
+
+    fn bin_op(
+        &self,
+        bin_op: super::TypingBinOp,
+        rhs: &TyBasic,
+        _ctx: &TypingOracleCtx,
+    ) -> Result<Ty, TypingNoContextOrInternalError> {
+        Ok(self.base.bin_op(bin_op, rhs)?)
+    }
+
+    fn rbin_op(
+        &self,
+        bin_op: super::TypingBinOp,
+        lhs: &TyBasic,
+        _ctx: &TypingOracleCtx,
+    ) -> Result<Ty, TypingNoContextOrInternalError> {
+        Ok(self.base.rbin_op(bin_op, lhs)?)
+    }
 }
 
 #[cfg(test)]
@@ -414,6 +432,14 @@ mod tests {
         fn get_type_starlark_repr() -> Ty {
             Ty::starlark_value::<Fruit>()
         }
+
+        fn add(&self, _other: Value<'v>, _heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
+            unreachable!("not needed in tests, but typechecker requires it")
+        }
+
+        fn rdiv(&self, _lhs: Value<'v>, _heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
+            unreachable!("not needed in tests, but typechecker requires it")
+        }
     }
 
     #[starlark_module]
@@ -487,6 +513,32 @@ def test():
     # They should intersect.
     takes_pear(mk_fruit())
 "#,
+        );
+    }
+
+    #[test]
+    fn test_ty_user_delegates_bin_ops_to_base_starlark_value() {
+        let mut a = Assert::new();
+        a.globals_add(globals);
+        a.pass(
+            r#"
+Apple = fruit("apple")
+
+def add_apples(x: Apple, y: Apple):
+    return x + y
+
+def divide_by_apple(x: Apple):
+    return 1 / x
+"#,
+        );
+        a.fail(
+            r#"
+Apple = fruit("apple")
+
+def shift_apple(x: Apple, y: Apple):
+    return x << y
+"#,
+            "Binary operator",
         );
     }
 }

--- a/starlark/src/values/freeze.rs
+++ b/starlark/src/values/freeze.rs
@@ -65,6 +65,14 @@ pub trait Freeze {
     fn freeze(self, freezer: &Freezer) -> FreezeResult<Self::Frozen>;
 }
 
+impl Freeze for rust_decimal::Decimal {
+    type Frozen = rust_decimal::Decimal;
+
+    fn freeze(self, _freezer: &Freezer) -> FreezeResult<rust_decimal::Decimal> {
+        Ok(self)
+    }
+}
+
 impl Freeze for String {
     type Frozen = String;
 

--- a/starlark/src/values/layout/value.rs
+++ b/starlark/src/values/layout/value.rs
@@ -629,7 +629,13 @@ impl<'v> Value<'v> {
 
     /// `x / other`.
     pub fn div(self, other: Value<'v>, heap: Heap<'v>) -> crate::Result<Value<'v>> {
-        self.get_ref().div(other, heap)
+        match self.get_ref().div(other, heap) {
+            Some(r) => r,
+            _ => match other.get_ref().rdiv(self, heap) {
+                Some(r) => r,
+                _ => ValueError::unsupported_owned(self.get_type(), "/", Some(other.get_type())),
+            },
+        }
     }
 
     /// `x // other`.

--- a/starlark/src/values/layout/vtable.rs
+++ b/starlark/src/values/layout/vtable.rs
@@ -593,8 +593,13 @@ impl<'v> AValueDyn<'v> {
     }
 
     #[inline]
-    pub(crate) fn div(self, other: Value<'v>, heap: Heap<'v>) -> crate::Result<Value<'v>> {
+    pub(crate) fn div(self, other: Value<'v>, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
         (self.vtable.starlark_value.div)(self.value, other, heap)
+    }
+
+    #[inline]
+    pub(crate) fn rdiv(self, other: Value<'v>, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
+        (self.vtable.starlark_value.rdiv)(self.value, other, heap)
     }
 
     #[inline]

--- a/starlark/src/values/traits.rs
+++ b/starlark/src/values/traits.rs
@@ -735,7 +735,15 @@ pub trait StarlarkValue<'v>:
         None
     }
 
+    /// Called on `rhs` of `lhs / rhs` when `lhs.div` fails.
+    fn rdiv(&self, lhs: Value<'v>, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
+        let _ignore = (lhs, heap);
+        None
+    }
+
     /// Divide the current value by `other`. Always results in a float value.
+    ///
+    /// When this function returns `None`, starlark-rust calls `rhs.rdiv(lhs)`.
     ///
     /// # Examples
     ///
@@ -745,8 +753,8 @@ pub trait StarlarkValue<'v>:
     /// 7 / 2 == 3.5
     /// # "#);
     /// ```
-    fn div(&self, other: Value<'v>, _heap: Heap<'v>) -> crate::Result<Value<'v>> {
-        ValueError::unsupported_with(self, "/", other)
+    fn div(&self, _rhs: Value<'v>, _heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
+        None
     }
 
     /// Apply the percent operator between the current value and `other`. Usually used on

--- a/starlark/src/values/types/bigint.rs
+++ b/starlark/src/values/types/bigint.rs
@@ -244,10 +244,13 @@ impl<'v> StarlarkValue<'v> for StarlarkBigInt {
         )))
     }
 
-    fn div(&self, other: Value<'v>, heap: Heap<'v>) -> crate::Result<Value<'v>> {
+    fn div(&self, other: Value<'v>, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
         match other.unpack_num() {
-            Some(other) => Ok(heap.alloc(NumRef::Int(StarlarkIntRef::Big(self)).div(other)?)),
-            None => ValueError::unsupported_with(self, "/", other),
+            Some(other) => match NumRef::Int(StarlarkIntRef::Big(self)).div(other) {
+                Ok(result) => Some(Ok(heap.alloc(result))),
+                Err(e) => Some(Err(e.into())),
+            },
+            None => None,
         }
     }
 

--- a/starlark/src/values/types/float/float.rs
+++ b/starlark/src/values/types/float/float.rs
@@ -306,10 +306,13 @@ impl<'v> StarlarkValue<'v> for StarlarkFloat {
         Some(Ok(heap.alloc(NumRef::Float(*self) * other.unpack_num()?)))
     }
 
-    fn div(&self, other: Value, heap: Heap<'v>) -> crate::Result<Value<'v>> {
+    fn div(&self, other: Value, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
         match other.unpack_num() {
-            None => ValueError::unsupported_with(self, "/", other),
-            Some(other) => Ok(heap.alloc(NumRef::Float(*self).div(other)?)),
+            None => None,
+            Some(other) => match NumRef::Float(*self).div(other) {
+                Ok(result) => Some(Ok(heap.alloc(result))),
+                Err(e) => Some(Err(e.into())),
+            },
         }
     }
 

--- a/starlark/src/values/types/int/pointer_i32.rs
+++ b/starlark/src/values/types/int/pointer_i32.rs
@@ -181,12 +181,13 @@ impl<'v> StarlarkValue<'v> for PointerI32 {
             NumRef::Int(StarlarkIntRef::Small(self.get())) * other.unpack_num()?,
         )))
     }
-    fn div(&self, other: Value<'v>, heap: Heap<'v>) -> crate::Result<Value<'v>> {
+    fn div(&self, other: Value<'v>, heap: Heap<'v>) -> Option<crate::Result<Value<'v>>> {
         match other.unpack_num() {
-            Some(other) => {
-                Ok(heap.alloc(NumRef::Int(StarlarkIntRef::Small(self.get())).div(other)?))
-            }
-            None => ValueError::unsupported_with(self, "/", other),
+            Some(other) => match NumRef::Int(StarlarkIntRef::Small(self.get())).div(other) {
+                Ok(result) => Some(Ok(heap.alloc(result))),
+                Err(e) => Some(Err(e.into())),
+            },
+            None => None,
         }
     }
     fn percent(&self, other: Value<'v>, heap: Heap<'v>) -> crate::Result<Value<'v>> {

--- a/starlark/src/values/types/num/typecheck.rs
+++ b/starlark/src/values/types/num/typecheck.rs
@@ -81,6 +81,7 @@ pub(crate) fn typecheck_num_bin_op(lhs: NumTy, op: TypingBinOp, rhs: &TyBasic) -
         (NumTy::Int, BinOpClass::Add, NumRhsTy::Num(NumTy::Int)) => Some(Ty::int()),
         (_, BinOpClass::Add, NumRhsTy::Num(NumTy::Float)) => Some(Ty::float()),
         (_, BinOpClass::Add, NumRhsTy::Any) => Some(int_or_float()),
+        (_, BinOpClass::Div, NumRhsTy::Any) => Some(Ty::any()),
         (_, BinOpClass::Div, _) => Some(Ty::float()),
         (NumTy::Int, BinOpClass::BitAnd, NumRhsTy::Num(NumTy::Int) | NumRhsTy::Any) => {
             Some(Ty::int())

--- a/starlark/src/values/types/record.rs
+++ b/starlark/src/values/types/record.rs
@@ -41,7 +41,8 @@
 //! # "#);
 //! ```
 
-pub(crate) mod field;
+/// Field specifications for record types.
+pub mod field;
 pub(crate) mod globals;
 pub(crate) mod instance;
 pub(crate) mod matcher;
@@ -49,4 +50,5 @@ pub(crate) mod record_type;
 pub(crate) mod ty_record_type;
 
 pub use crate::values::record::instance::Record;
+pub use crate::values::record::record_type::FrozenRecordType;
 pub use crate::values::record::record_type::RecordType;

--- a/starlark/src/values/types/record/field.rs
+++ b/starlark/src/values/types/record/field.rs
@@ -79,6 +79,16 @@ impl<V: ValueLifetimeless> FieldGen<V> {
     pub(crate) fn new(typ: TypeCompiled<V>, default: Option<V>) -> Self {
         Self { typ, default }
     }
+
+    /// Get the type specification for this field (public accessor)
+    pub fn typ(&self) -> &TypeCompiled<V> {
+        &self.typ
+    }
+
+    /// Get the default value for this field (public accessor)
+    pub fn default(&self) -> Option<&V> {
+        self.default.as_ref()
+    }
 }
 
 impl<'v, V: ValueLike<'v>> FieldGen<V> {

--- a/starlark/src/values/typing/type_compiled/compiled.rs
+++ b/starlark/src/values/typing/type_compiled/compiled.rs
@@ -493,7 +493,8 @@ impl<'v> TypeCompiled<Value<'v>> {
         }
     }
 
-    pub(crate) fn from_ty(ty: &Ty, heap: Heap<'v>) -> Self {
+    /// Create compiled type from type information.
+    pub fn from_ty(ty: &Ty, heap: Heap<'v>) -> Self {
         TypeCompiledFactory::alloc_ty(ty, heap)
     }
 

--- a/starlark_derive/src/starlark_value.rs
+++ b/starlark_derive/src/starlark_value.rs
@@ -290,6 +290,7 @@ impl ImplStarlarkValue {
         let arms = [
             self.bin_op_arm("Add", "radd"),
             self.bin_op_arm("Mul", "rmul"),
+            self.bin_op_arm("Div", "rdiv"),
         ];
         if arms.iter().all(Option::is_none) {
             // Use default implementation.

--- a/starlark_lsp/src/server.rs
+++ b/starlark_lsp/src/server.rs
@@ -34,9 +34,7 @@ use lsp_server::Connection;
 use lsp_server::Message;
 use lsp_server::Notification;
 use lsp_server::ProtocolError;
-use lsp_server::Request;
 use lsp_server::RequestId;
-use lsp_server::Response;
 use lsp_server::ResponseError;
 use lsp_types::CompletionItem;
 use lsp_types::CompletionItemKind;
@@ -99,6 +97,9 @@ use starlark_syntax::codemap::ResolvedPos;
 use starlark_syntax::syntax::ast::AstPayload;
 use starlark_syntax::syntax::ast::LoadArgP;
 use starlark_syntax::syntax::module::AstModuleFields;
+
+pub use lsp_server::Request;
+pub use lsp_server::Response;
 
 use crate::completion::StringCompletionResult;
 use crate::completion::StringCompletionType;
@@ -396,6 +397,27 @@ pub trait LspContext {
     ) -> Result<Vec<StringCompletionResult>, String> {
         let _unused = (document_uri, kind, current_value, workspace_root);
         Ok(Vec::new())
+    }
+
+    /// Handle custom LSP request messages that are not recognised by the core `starlark_lsp`
+    /// implementation. Implementations should return [`Some(Response)`] when the request
+    /// identified by `req.method` has been handled, or [`None`] to signal that the message is
+    /// unsupported and can be safely ignored.
+    fn handle_custom_request(
+        &self,
+        _req: &lsp_server::Request,
+        _initialize_params: &lsp_types::InitializeParams,
+    ) -> Option<lsp_server::Response> {
+        None
+    }
+
+    /// Handle custom LSP notification messages that are not recognised by the core
+    /// implementation. The default implementation is a no-op.
+    fn handle_custom_notification(
+        &self,
+        _notification: &lsp_server::Notification,
+        _initialize_params: &lsp_types::InitializeParams,
+    ) {
     }
 }
 
@@ -1264,6 +1286,10 @@ impl<T: LspContext> Backend<T> {
                         self.hover(req.id, params, &initialize_params);
                     } else if self.connection.handle_shutdown(&req)? {
                         return Ok(());
+                    } else if let Some(resp) =
+                        self.context.handle_custom_request(&req, &initialize_params)
+                    {
+                        self.send_response(resp);
                     }
                     // Currently don't handle any other requests
                 }
@@ -1274,6 +1300,9 @@ impl<T: LspContext> Backend<T> {
                         self.maybe_log_error(self.did_change(params));
                     } else if let Some(params) = as_notification::<DidCloseTextDocument>(&x) {
                         self.maybe_log_error(self.did_close(params));
+                    } else {
+                        self.context
+                            .handle_custom_notification(&x, &initialize_params);
                     }
                 }
                 Message::Response(_) => {
@@ -2551,6 +2580,27 @@ mod tests {
                 case.2
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn custom_request_echo() -> anyhow::Result<()> {
+        if starlark::wasm::is_wasm() {
+            return Ok(());
+        }
+
+        struct EchoRequest;
+        impl lsp_types::request::Request for EchoRequest {
+            type Params = String;
+            type Result = String;
+            const METHOD: &'static str = "starlark/echo";
+        }
+
+        let mut server = TestServer::new()?;
+        let req = server.new_request::<EchoRequest>("ping".to_owned());
+        let request_id = server.send_request(req)?;
+        let response: String = server.get_response(request_id)?;
+        assert_eq!(response, "echo:ping");
         Ok(())
     }
 }

--- a/starlark_lsp/src/test.rs
+++ b/starlark_lsp/src/test.rs
@@ -301,6 +301,23 @@ impl LspContext for TestServerContext {
                 .collect(),
         }
     }
+
+    fn handle_custom_request(
+        &self,
+        req: &lsp_server::Request,
+        _initialize_params: &lsp_types::InitializeParams,
+    ) -> Option<lsp_server::Response> {
+        if req.method == "starlark/echo" {
+            let payload: String = serde_json::from_value(req.params.clone()).ok()?;
+            Some(lsp_server::Response {
+                id: req.id.clone(),
+                result: Some(serde_json::to_value(format!("echo:{}", payload)).unwrap()),
+                error: None,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 /// A server for use in testing that provides helpers for sending requests, correlating


### PR DESCRIPTION
These are trimmed down to just what's needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes module binding semantics via export_as replacement (eval path) and removes pagable storage backends; div/rdiv and typing behavior shifts are user-visible but covered by tests.
> 
> **Overview**
> This PR trims **pagable** and extends **starlark** / **starlark_lsp** for Diode-style use.
> 
> **pagable** drops optional persistence and map support: workspace and crate dependencies no longer pull in `sled`, `rusqlite`, or `sorted_vector_map`; `pagable` is not built with the default `tokio` feature at the workspace level. `SortedVectorMap` pagable serialize/deserialize and its roundtrip test are removed, and `storage` no longer exposes `sled` / `sqlite` modules (in-memory path remains).
> 
> **starlark** adds **`export_as` replacement** for top-level module bindings: `Evaluator::export_as_module_binding` runs `export_as` with a stack so hooks can call `set_export_as_replacement` (including nested binds via `set_module_variable_at_some_point`); bytecode module export/store paths use the resolved value. Division tries `lhs.div` then **`rhs.rdiv(lhs)`** (`div` on values now returns `Option`). The typechecker gains **`rbin_op`** on custom types (including `TyUser` delegating to its base) and derives `rdiv` typing where applicable. **`rust_decimal::Decimal`** can be frozen; **`Option`** gets `Coerce` impls; record **`field`** is public with `typ`/`default` accessors and **`FrozenRecordType`** is re-exported; **`TypeCompiled::from_ty`** is public. WASM module freeze no longer uses `Instant` for total eval duration.
> 
> **starlark_lsp** lets embedders handle unknown traffic via **`LspContext::handle_custom_request`** / **`handle_custom_notification`**, re-exports `Request`/`Response`, and includes an echo custom-request test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a73b696d5f72085d85b04fc065d35e56eb32662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->