### PR TITLE
Return type for add operator class with untyped operand

### DIFF
--- a/starlark/src/typing/user.rs
+++ b/starlark/src/typing/user.rs
@@ -541,4 +541,24 @@ def shift_apple(x: Apple, y: Apple):
             "Binary operator",
         );
     }
+
+    #[test]
+    fn test_ty_num_bin_op_with_untyped_operand_is_any() {
+        let mut a = Assert::new();
+        a.pass(
+            r#"
+def mul(x): return (1.0 * x).anything
+def add(x): return (1.0 + x).anything
+def sub(x): return (1.0 - x).anything
+def div(x): return (1.0 / x).anything
+"#,
+        );
+        a.fail(
+            r#"
+def bad():
+    return (1.0 * 2.0).anything
+"#,
+            "not available",
+        );
+    }
 }

--- a/starlark/src/values/types/num/typecheck.rs
+++ b/starlark/src/values/types/num/typecheck.rs
@@ -29,10 +29,6 @@ enum NumRhsTy {
     Any,
 }
 
-fn int_or_float() -> Ty {
-    Ty::union2(Ty::int(), Ty::float())
-}
-
 /// Group of operators sharing the typing behavior.
 enum BinOpClass {
     /// If any operand is a float, the result is a float.
@@ -77,10 +73,10 @@ pub(crate) fn typecheck_num_bin_op(lhs: NumTy, op: TypingBinOp, rhs: &TyBasic) -
     match (lhs, op, rhs) {
         (_, BinOpClass::In, _) => None,
         (_, BinOpClass::Less, _) => Some(Ty::bool()),
+        (_, BinOpClass::Add, NumRhsTy::Any) => Some(Ty::any()),
         (NumTy::Float, BinOpClass::Add, _) => Some(Ty::float()),
         (NumTy::Int, BinOpClass::Add, NumRhsTy::Num(NumTy::Int)) => Some(Ty::int()),
         (_, BinOpClass::Add, NumRhsTy::Num(NumTy::Float)) => Some(Ty::float()),
-        (_, BinOpClass::Add, NumRhsTy::Any) => Some(int_or_float()),
         (_, BinOpClass::Div, NumRhsTy::Any) => Some(Ty::any()),
         (_, BinOpClass::Div, _) => Some(Ty::float()),
         (NumTy::Int, BinOpClass::BitAnd, NumRhsTy::Num(NumTy::Int) | NumRhsTy::Any) => {


### PR DESCRIPTION
Bug discovered when doing diodeinc/pcb#915

The type checker types 1.0 * x as float when x is untyped (any)

In pcb#915 (FerriteBead.zen): we have `cp_val = 1.0 / (2 * pi * freq * rac)`, where freq and rac come from config (so typed as any).
The result is typed as float, so  the new spice() function is rejected and the module fails to load.

The fix match what was already been done for Div

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to numeric binary-op typing in the typechecker, covered by new tests; no runtime behavior change.
> 
> **Overview**
> Fixes incorrect **float** inference when a numeric literal is combined with an **untyped (`any`)** operand (e.g. config values), which blocked downstream APIs that expect **`any`**.
> 
> **`typecheck_num_bin_op`** now types add/sub/mul-style ops with **`NumRhsTy::Any`** as **`Ty::any()`** instead of **`int | float`**. Division with an **`any`** rhs was already **`any`**; the add-class rule is aligned with that. The unused **`int_or_float()`** helper is removed.
> 
> A regression test asserts **`1.0 *` / `+` / `-` / `/` `x`** (untyped **`x`**) allow **`.anything`**, while **`1.0 * 2.0`** still resolves to **float** and rejects **`.anything`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3973177b8f9d4445648ee66b649b054c8e03cef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->